### PR TITLE
Fix use preprocessor options from arguments

### DIFF
--- a/libsquoosh/src/index.ts
+++ b/libsquoosh/src/index.ts
@@ -189,16 +189,17 @@ class Image {
       else {
         preprocessorOptions = {
           ...preprocessors[preprocessorName].defaultOptions,
+          ...(options as object),
         };
-
-        this.decoded = this.workerPool.dispatchJob({
-          operation: 'preprocess',
-          preprocessorName,
-          image: await this.decoded,
-          options: preprocessorOptions,
-        });
-        await this.decoded;
       }
+
+      this.decoded = this.workerPool.dispatchJob({
+        operation: 'preprocess',
+        preprocessorName,
+        image: await this.decoded,
+        options: preprocessorOptions,
+      });
+      await this.decoded;
     }
   }
 


### PR DESCRIPTION
Fixes issue #3 

**Excerpt**
When using the preprocessors arguments (--resize, --quant, --rotate) with options (either an Object or a stringified Object), the options are not used in Image.preprocess().