### PR TITLE
Prevent codecs load via `fetch()`

### DIFF
--- a/libsquoosh/rollup.config.js
+++ b/libsquoosh/rollup.config.js
@@ -15,6 +15,12 @@ export default {
     dir: 'build',
     format: 'cjs',
     assetFileNames: '[name]-[hash][extname]',
+    /*
+    `fetch` in Node.js dones't support `file:` protocol,
+    add this to make fetch a local undefined variable so the codecs
+    won't load via `fetch()`
+    */
+    banner: 'var fetch;',
   },
   plugins: [
     resolve(),


### PR DESCRIPTION
A hacky way to make the lib usable without `--no-experimental-fetch`, I'm using this hack by adding `var fetch;` to the entry file before import the package. https://github.com/fisker/vite-plugin-image-squoosh/pull/3/files